### PR TITLE
Make createSpan actually optional

### DIFF
--- a/instana.php
+++ b/instana.php
@@ -54,7 +54,7 @@ if (false === extension_loaded('instana') && false === class_exists('Instana\Tra
          * @param int $type - optional span type one of Span::ENTRY, Span::EXIT or Span::LOCAL
          * @return Span
          */
-        public function createSpan($category, $type){
+        public function createSpan($category, $type = Span::LOCAL){
             return new Span();
         }
 


### PR DESCRIPTION
Right now our static analysis tools are telling us that createSpan needs two params, as its not optional in these stubs.

I assume the default type is `Span::LOCAL`, and have marked it as such.